### PR TITLE
Add the restart and recompile commands.  Fixes #4

### DIFF
--- a/cmd/slacktest/main.go
+++ b/cmd/slacktest/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/riking/marvin/slack"
 	"github.com/riking/marvin/slack/controller"
 	"github.com/riking/marvin/slack/rtm"
+	"github.com/riking/marvin/modules/restart"
 	"github.com/riking/marvin/util"
 	"gopkg.in/ini.v1"
 )
@@ -164,5 +165,8 @@ func main() {
 		}(v)
 	}
 	wg.Wait()
+	if restart.RestartInProgress {
+		os.Exit(14)
+	}
 	return
 }

--- a/cmd/slacktest/main.go
+++ b/cmd/slacktest/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/riking/marvin/slack"
 	"github.com/riking/marvin/slack/controller"
 	"github.com/riking/marvin/slack/rtm"
-	"github.com/riking/marvin/modules/restart"
 	"github.com/riking/marvin/util"
 	"gopkg.in/ini.v1"
 )
@@ -165,8 +164,6 @@ func main() {
 		}(v)
 	}
 	wg.Wait()
-	if restart.RestartInProgress {
-		os.Exit(14)
-	}
+	os.Exit(14)
 	return
 }

--- a/modules/_all/import.go
+++ b/modules/_all/import.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/riking/marvin/modules/logger"
 	_ "github.com/riking/marvin/modules/on_reaction"
 	_ "github.com/riking/marvin/modules/paste"
+	_ "github.com/riking/marvin/modules/restart"
 	_ "github.com/riking/marvin/modules/rss"
 	_ "github.com/riking/marvin/modules/timedpin"
 	_ "github.com/riking/marvin/modules/weblogin"

--- a/modules/restart/restart.go
+++ b/modules/restart/restart.go
@@ -59,22 +59,24 @@ func (mod *RestartModule) RecompileCommand(t marvin.Team, args *marvin.CommandAr
 	select {
 	case <-recompileSemaphore:
 		// defer reinserting the token until the recompile command is finished.
-		defer func() { recompileSemaphore <- struct{}{} }()
-		stdout, err := mod.Recompile()
-		if err != nil {
-			return marvin.CmdError(args, err, fmt.Sprintf("Failed to recompile: \n%s", stdout))
-		}
-
-		mod.team.SendMessage(mod.team.TeamConfig().LogChannel, fmt.Sprintf("Successfully recompiled: \n%s", stdout))
-
-		if len(args.Arguments) == 1 && args.Arguments[0] == "restart" {
-			go mod.Restart()
-		}
-
-		return marvin.CmdSuccess(args, "Successfully recompiled.")
+		break
 	default:
 		return marvin.CmdFailuref(args, "There is a recompile in progress.")
 	}
+
+	defer func() { recompileSemaphore <- struct{}{} }()
+	stdout, err := mod.Recompile()
+	if err != nil {
+		return marvin.CmdError(args, err, fmt.Sprintf("Failed to recompile: \n%s", stdout))
+	}
+
+	mod.team.SendMessage(mod.team.TeamConfig().LogChannel, fmt.Sprintf("Successfully recompiled: \n%s", stdout))
+
+	if len(args.Arguments) == 1 && args.Arguments[0] == "restart" {
+		go mod.Restart()
+	}
+
+	return marvin.CmdSuccess(args, "Successfully recompiled.")
 }
 
 func (mod *RestartModule) RestartCommand(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {

--- a/modules/restart/restart.go
+++ b/modules/restart/restart.go
@@ -1,11 +1,12 @@
 package restart
 
 import (
-	"github.com/riking/marvin"
 	"fmt"
-	"syscall"
-	"os/exec"
 	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/riking/marvin"
 )
 
 func init() {
@@ -15,7 +16,6 @@ func init() {
 const Identifier = "restart"
 
 var RecompileInProgress = false
-var RestartInProgress = false
 
 type RestartModule struct {
 	team marvin.Team
@@ -36,22 +36,19 @@ func (mod *RestartModule) Load(t marvin.Team) {
 }
 
 func (mod *RestartModule) Enable(team marvin.Team) {
-	cmd := team.RegisterCommandFunc("restart", mod.RestartCommand,
+	team.RegisterCommandFunc("restart", mod.RestartCommand,
 		"`@marvin restart`"+
 			"This restarts the active Marvin instance.\n")
-	cmd2 := team.RegisterCommandFunc("recompile", mod.RecompileCommand,
+	team.RegisterCommandFunc("recompile", mod.RecompileCommand,
 		"`@marvin recompile`"+
-			"This recompiles Marvin from git.\n")
-	team.RegisterCommand("restart", cmd)
-	team.RegisterCommand("recompile", cmd2)
+			"This recompiles Marvin, pulling the latest changes.\n")
 }
 
 func (mod *RestartModule) Disable(t marvin.Team) {
 }
 
-
 func (mod *RestartModule) RecompileCommand(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
-	if args.Source.AccessLevel() < marvin.AccessLevelAdmin {
+	if args.Source.AccessLevel() < marvin.AccessLevelController {
 		return marvin.CmdFailuref(args, "This command is restricted to admins only.")
 	}
 
@@ -59,12 +56,11 @@ func (mod *RestartModule) RecompileCommand(t marvin.Team, args *marvin.CommandAr
 		return marvin.CmdFailuref(args, "There is an already existing recompile in progress.")
 	}
 
-	go mod.RecompileMarvin(t)
-	return marvin.CmdSuccess(args, "Sent command to recompile.")
+	return mod.RecompileMarvin(args)
 }
 
 func (mod *RestartModule) RestartCommand(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
-	if args.Source.AccessLevel() < marvin.AccessLevelAdmin {
+	if args.Source.AccessLevel() < marvin.AccessLevelController {
 		return marvin.CmdFailuref(args, "This command is restricted to admins only.")
 	}
 
@@ -72,30 +68,29 @@ func (mod *RestartModule) RestartCommand(t marvin.Team, args *marvin.CommandArgu
 		return marvin.CmdFailuref(args, "There is an recompile in progress.")
 	}
 
-	go mod.RestartMarvin(t)
+	go mod.RestartMarvin()
 	return marvin.CmdSuccess(args, "I am restarting now, be back soon.")
 }
 
-func (mod *RestartModule) RecompileMarvin(t marvin.Team) {
+func (mod *RestartModule) RecompileMarvin(args *marvin.CommandArguments) marvin.CommandResult {
 	RecompileInProgress = true
-	t.SendMessage(t.TeamConfig().LogChannel, "Recompiling Marvin....")
-	cmd := exec.Command("/bin/sh", os.Getenv("PWD") + "/recompile.sh")
-	stdout, err := cmd.Output()
+	mod.team.SendMessage(args.Source.ChannelID(), "Recompiling Marvin....")
+	cmd := exec.Command("/bin/sh", os.Getenv("HOME")+"/marvin/build.sh")
+	stdout, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Printf("Failed to recompile Marvin: \n%s", stdout)
-		t.SendMessage(t.TeamConfig().LogChannel, fmt.Sprintf("Failed to recompile Marvin: \n%s", stdout))
 		RecompileInProgress = false
-		return
+		return marvin.CmdFailuref(args, fmt.Sprintf("Failed to recompile Marvin: \n%s", stdout))
 	}
 
-	t.SendMessage(t.TeamConfig().LogChannel, "Successfully recompiled Marvin!")
+	mod.team.SendMessage(mod.team.TeamConfig().LogChannel, "Successfully recompiled Marvin!")
 	fmt.Printf("Compile Logs: \n%s", fmt.Sprintf("%s", stdout))
 	RecompileInProgress = false
+	return marvin.CmdSuccess(args, "Successfully recompiled marvin.")
 }
 
-func (mod *RestartModule) RestartMarvin(t marvin.Team) {
+func (mod *RestartModule) RestartMarvin() {
 	fmt.Printf("Restarting Marvin...")
-	RestartInProgress = true
-	t.SendMessage(t.TeamConfig().LogChannel, "Restarting Marvin...be back soon.")
+	mod.team.SendMessage(mod.team.TeamConfig().LogChannel, "Restarting Marvin...be back soon.")
 	syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 }

--- a/modules/restart/restart.go
+++ b/modules/restart/restart.go
@@ -42,7 +42,7 @@ func (mod *RestartModule) Enable(team marvin.Team) {
 			"This restarts the active Marvin instance.\n")
 	team.RegisterCommandFunc("recompile", mod.RecompileCommand,
 		"`@marvin recompile [restart]`"+
-			"This recompiles Marvin, pulling the latest changes.\n" +
+			"This recompiles Marvin, pulling the latest changes.\n"+
 			"With optional parameter, restarts the server after a successful compile.\n")
 }
 

--- a/modules/restart/restart.go
+++ b/modules/restart/restart.go
@@ -1,0 +1,101 @@
+package restart
+
+import (
+	"github.com/riking/marvin"
+	"fmt"
+	"syscall"
+	"os/exec"
+	"os"
+)
+
+func init() {
+	marvin.RegisterModule(NewRestartModule)
+}
+
+const Identifier = "restart"
+
+var RecompileInProgress = false
+var RestartInProgress = false
+
+type RestartModule struct {
+	team marvin.Team
+}
+
+func NewRestartModule(t marvin.Team) marvin.Module {
+	mod := &RestartModule{
+		team: t,
+	}
+	return mod
+}
+
+func (mod *RestartModule) Identifier() marvin.ModuleID {
+	return Identifier
+}
+
+func (mod *RestartModule) Load(t marvin.Team) {
+}
+
+func (mod *RestartModule) Enable(team marvin.Team) {
+	cmd := team.RegisterCommandFunc("restart", mod.RestartCommand,
+		"`@marvin restart`"+
+			"This restarts the active Marvin instance.\n")
+	cmd2 := team.RegisterCommandFunc("recompile", mod.RecompileCommand,
+		"`@marvin recompile`"+
+			"This recompiles Marvin from git.\n")
+	team.RegisterCommand("restart", cmd)
+	team.RegisterCommand("recompile", cmd2)
+}
+
+func (mod *RestartModule) Disable(t marvin.Team) {
+}
+
+
+func (mod *RestartModule) RecompileCommand(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
+	if args.Source.AccessLevel() < marvin.AccessLevelAdmin {
+		return marvin.CmdFailuref(args, "This command is restricted to admins only.")
+	}
+
+	if RecompileInProgress {
+		return marvin.CmdFailuref(args, "There is an already existing recompile in progress.")
+	}
+
+	go mod.RecompileMarvin(t)
+	return marvin.CmdSuccess(args, "Sent command to recompile.")
+}
+
+func (mod *RestartModule) RestartCommand(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
+	if args.Source.AccessLevel() < marvin.AccessLevelAdmin {
+		return marvin.CmdFailuref(args, "This command is restricted to admins only.")
+	}
+
+	if RecompileInProgress {
+		return marvin.CmdFailuref(args, "There is an recompile in progress.")
+	}
+
+	go mod.RestartMarvin(t)
+	return marvin.CmdSuccess(args, "I am restarting now, be back soon.")
+}
+
+func (mod *RestartModule) RecompileMarvin(t marvin.Team) {
+	RecompileInProgress = true
+	t.SendMessage(t.TeamConfig().LogChannel, "Recompiling Marvin....")
+	cmd := exec.Command("/bin/sh", os.Getenv("PWD") + "/recompile.sh")
+	stdout, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("Failed to recompile Marvin: \n%s", stdout)
+		t.SendMessage(t.TeamConfig().LogChannel, fmt.Sprintf("Failed to recompile Marvin: \n%s", stdout))
+		RecompileInProgress = false
+		return
+	}
+
+	t.SendMessage(t.TeamConfig().LogChannel, "Successfully recompiled Marvin!")
+	fmt.Printf("Compile Logs: \n%s", fmt.Sprintf("%s", stdout))
+	RecompileInProgress = false
+}
+
+func (mod *RestartModule) RestartMarvin(t marvin.Team) {
+	fmt.Printf("Restarting Marvin...")
+	RestartInProgress = true
+	t.SendMessage(t.TeamConfig().LogChannel, "Restarting Marvin...be back soon.")
+	syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+}

--- a/modules/restart/restart.go
+++ b/modules/restart/restart.go
@@ -86,13 +86,15 @@ func (mod *RestartModule) RestartCommand(t marvin.Team, args *marvin.CommandArgu
 
 	select {
 	case <-recompileSemaphore:
-		defer func() { recompileSemaphore <- struct{}{} }()
-
-		go mod.Restart()
-		return marvin.CmdSuccess(args, "Restarting, be back soon.")
+		break
 	default:
 		return marvin.CmdFailuref(args, "There is a recompile in progress.")
 	}
+
+	defer func() { recompileSemaphore <- struct{}{} }()
+
+	go mod.Restart()
+	return marvin.CmdSuccess(args, "Restarting, be back soon.")
 }
 
 // Execute the shell script located in $HOME/marvin/build (with +x perms).

--- a/modules/restart/restart.go
+++ b/modules/restart/restart.go
@@ -58,12 +58,12 @@ func (mod *RestartModule) RecompileCommand(t marvin.Team, args *marvin.CommandAr
 	// Otherwise it will recompile.
 	select {
 	case <-recompileSemaphore:
-		// defer reinserting the token until the recompile command is finished.
 		break
 	default:
 		return marvin.CmdFailuref(args, "There is a recompile in progress.")
 	}
 
+	// defer reinserting the token until the recompile command is finished.
 	defer func() { recompileSemaphore <- struct{}{} }()
 	stdout, err := mod.Recompile()
 	if err != nil {

--- a/recompile.sh
+++ b/recompile.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-go build -v github.com/riking/marvin/cmd/slacktest 2>&1
-if [ "$?" != 0 ]; then
-    echo "Failed to compile."
-    exit 127
-fi
-mv slacktest $HOME/go/bin/ 2>&1

--- a/recompile.sh
+++ b/recompile.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+go build -v github.com/riking/marvin/cmd/slacktest 2>&1
+if [ "$?" != 0 ]; then
+    echo "Failed to compile."
+    exit 127
+fi
+mv slacktest $HOME/go/bin/ 2>&1


### PR DESCRIPTION
See #4 

This works according to what was requested.  It exits with 14 (only) if the restart command is executed.  Compile errors go to both console & the log channel if necessary.  It does not automatically restart after the recompile.

You may need to refine the recompile.sh script accordingly, as this works when the current directory is in the GOPATH (go/src/github.com/riking/marvin).

I'm also not too sure about how to pass the flag for the exit code to occur (if the command was executed) without importing the module (see [here](https://github.com/riking/marvin/compare/master...SuperSpyTX:patch-restart-recompile?expand=1#diff-047912ae4e22f5323fe4d8a2a8004712)), so if that matters to you, I can try to find another way.

EDIT: Make sure you're redirecting stderr to stdout, or else Marvin won't have logs to read.  Eg: `2>&1`