### PR TITLE
Read only patch

### DIFF
--- a/modules/_all/import.go
+++ b/modules/_all/import.go
@@ -14,6 +14,6 @@ import (
 	_ "github.com/riking/marvin/modules/paste"
 	_ "github.com/riking/marvin/modules/restart"
 	_ "github.com/riking/marvin/modules/rss"
-	_ "github.com/riking/marvin/modules/timedpin"
+	//_ "github.com/riking/marvin/modules/timedpin"
 	_ "github.com/riking/marvin/modules/weblogin"
 )

--- a/modules/autoinvite/autoinvite.go
+++ b/modules/autoinvite/autoinvite.go
@@ -241,6 +241,9 @@ type postInviteResult struct {
 }
 
 func (mod *AutoInviteModule) PostInvite(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
+	if mod.team.TeamConfig().IsReadOnly {
+		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No new invites can currently be created.")
+	}
 	util.LogDebug("PostInvite", args.Arguments)
 
 	if len(args.Arguments) < 1 {
@@ -407,6 +410,9 @@ func (mod *AutoInviteModule) SaveInvite(
 }
 
 func (mod *AutoInviteModule) CmdRevokeInvite(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
+	if mod.team.TeamConfig().IsReadOnly && args.Source.AccessLevel() < marvin.AccessLevelAdmin {
+		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No invites can currently be revoked.")
+	}
 	stmt, err := mod.team.DB().Prepare(sqlRevokeInvite)
 	if err != nil {
 		return marvin.CmdError(args, err, "database error")

--- a/modules/autoinvite/autoinvite.go
+++ b/modules/autoinvite/autoinvite.go
@@ -242,7 +242,7 @@ type postInviteResult struct {
 
 func (mod *AutoInviteModule) PostInvite(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
 	if mod.team.TeamConfig().IsReadOnly {
-		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No new invites can currently be created.")
+		return marvin.CmdFailuref(args, "Marvin is currently on read only.")
 	}
 	util.LogDebug("PostInvite", args.Arguments)
 
@@ -411,7 +411,7 @@ func (mod *AutoInviteModule) SaveInvite(
 
 func (mod *AutoInviteModule) CmdRevokeInvite(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
 	if mod.team.TeamConfig().IsReadOnly && args.Source.AccessLevel() < marvin.AccessLevelAdmin {
-		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No invites can currently be revoked.")
+		return marvin.CmdFailuref(args, "Marvin is currently on read only.")
 	}
 	stmt, err := mod.team.DB().Prepare(sqlRevokeInvite)
 	if err != nil {

--- a/modules/autoinvite/massinvite.go
+++ b/modules/autoinvite/massinvite.go
@@ -14,7 +14,7 @@ const usageMass = "*`@marvin mass-invite`* will invite multiple people to a chan
 	"Use the command from the channel you want to invite users to."
 
 func CmdMassInvite(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
-	if args.Source.AccessLevel() < AccessLevelController {
+	if args.Source.AccessLevel() < marvin.AccessLevelController {
 		return marvin.CmdFailuref(args, "This command has been restricted to bot controller only.")
 	}
 	if len(args.Arguments) == 0 {

--- a/modules/autoinvite/massinvite.go
+++ b/modules/autoinvite/massinvite.go
@@ -14,6 +14,9 @@ const usageMass = "*`@marvin mass-invite`* will invite multiple people to a chan
 	"Use the command from the channel you want to invite users to."
 
 func CmdMassInvite(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
+	if args.Source.AccessLevel() < AccessLevelController {
+		return marvin.CmdFailuref(args, "This command has been restricted to bot controller only.")
+	}
 	if len(args.Arguments) == 0 {
 		return marvin.CmdUsage(args, usageMass).WithSimpleUndo()
 	}

--- a/modules/debug/debug.go
+++ b/modules/debug/debug.go
@@ -95,6 +95,9 @@ func (mod *DebugModule) DebugCommandSuccess(t marvin.Team, args *marvin.CommandA
 }
 
 func (mod *DebugModule) DebugCommandPaste(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
+	if mod.team.TeamConfig().IsReadOnly {
+		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No factoids can currently be created.")
+	}
 	content := strings.Join(args.Arguments, " ")
 	id, err := mod.pasteModule.(paste.API).CreatePaste(content)
 	if err != nil {

--- a/modules/debug/debug.go
+++ b/modules/debug/debug.go
@@ -96,7 +96,7 @@ func (mod *DebugModule) DebugCommandSuccess(t marvin.Team, args *marvin.CommandA
 
 func (mod *DebugModule) DebugCommandPaste(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
 	if mod.team.TeamConfig().IsReadOnly {
-		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No factoids can currently be created.")
+		return marvin.CmdFailuref(args, "Marvin is currently on read only.")
 	}
 	content := strings.Join(args.Arguments, " ")
 	id, err := mod.pasteModule.(paste.API).CreatePaste(content)

--- a/modules/factoid/commands.go
+++ b/modules/factoid/commands.go
@@ -261,7 +261,7 @@ func (mod *FactoidModule) CmdForget(t marvin.Team, args *marvin.CommandArguments
 	}
 	if mod.team.TeamConfig().IsReadOnly && args.Source.AccessLevel() < marvin.AccessLevelAdmin {
 		// Remove factoids from DB manx2ually.
-		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No factoids can currently be removed.")
+		return marvin.CmdFailuref(args, "Marvin is currently on read only.")
 	}
 	factoidName := args.Pop()
 	if len(factoidName) > FactoidNameMaxLen {

--- a/modules/factoid/commands.go
+++ b/modules/factoid/commands.go
@@ -259,7 +259,10 @@ func (mod *FactoidModule) CmdForget(t marvin.Team, args *marvin.CommandArguments
 	if len(args.Arguments) != 1 {
 		return marvin.CmdUsage(args, helpForget)
 	}
-
+	if mod.team.TeamConfig().IsReadOnly && args.Source.AccessLevel() < marvin.AccessLevelAdmin {
+		// Remove factoids from DB manx2ually.
+		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No factoids can currently be removed.")
+	}
 	factoidName := args.Pop()
 	if len(factoidName) > FactoidNameMaxLen {
 		return marvin.CmdFailuref(args, "Factoid name too long").WithEdit().WithSimpleUndo()

--- a/modules/factoid/database.go
+++ b/modules/factoid/database.go
@@ -400,10 +400,6 @@ func (mod *FactoidModule) ListFactoidsWithInfo(match string, channel slack.Chann
 }
 
 func (mod *FactoidModule) ForgetFactoid(dbID int64, isForgotten bool) error {
-	if mod.team.TeamConfig().IsReadOnly && args.Source.AccessLevel() < marvin.AccessLevelAdmin {
-		// Remove factoids from DB manually.
-		return errors.Errorf("Marvin is currently on read only mode.  No factoids can currently be removed.")
-	}
 	stmt, err := mod.team.DB().Prepare(sqlForgetFactoid)
 	if err != nil {
 		return errors.Wrap(err, "Database error")

--- a/modules/factoid/database.go
+++ b/modules/factoid/database.go
@@ -296,7 +296,7 @@ func (fi *Factoid) FillInfo(channel slack.ChannelID) error {
 
 func (mod *FactoidModule) SaveFactoid(name string, channel slack.ChannelID, rawSource string, source marvin.ActionSource) error {
 	if mod.team.TeamConfig().IsReadOnly {
-		return errors.Errorf("Marvin is currently on read only mode.  No factoids can currently be created.")
+		return errors.Errorf("Marvin is currently on read only.")
 	}
 	if len(name) > FactoidNameMaxLen {
 		return errors.Errorf("Factoid name is too long (%d > %d)", len(name), FactoidNameMaxLen)
@@ -415,7 +415,7 @@ func (mod *FactoidModule) ForgetFactoid(dbID int64, isForgotten bool) error {
 
 func (mod *FactoidModule) LockFactoid(dbID int64, isLocked bool) error {
 	if mod.team.TeamConfig().IsReadOnly {
-		return errors.Errorf("Marvin is currently on read only mode.  No factoids can currently be locked.")
+		return errors.Errorf("Marvin is currently on read only.")
 	}
 	stmt, err := mod.team.DB().Prepare(sqlLockFactoid)
 	if err != nil {

--- a/modules/factoid/database.go
+++ b/modules/factoid/database.go
@@ -295,6 +295,9 @@ func (fi *Factoid) FillInfo(channel slack.ChannelID) error {
 }
 
 func (mod *FactoidModule) SaveFactoid(name string, channel slack.ChannelID, rawSource string, source marvin.ActionSource) error {
+	if mod.team.TeamConfig().IsReadOnly {
+		return errors.Errorf("Marvin is currently on read only mode.  No factoids can currently be created.")
+	}
 	if len(name) > FactoidNameMaxLen {
 		return errors.Errorf("Factoid name is too long (%d > %d)", len(name), FactoidNameMaxLen)
 	}
@@ -397,6 +400,10 @@ func (mod *FactoidModule) ListFactoidsWithInfo(match string, channel slack.Chann
 }
 
 func (mod *FactoidModule) ForgetFactoid(dbID int64, isForgotten bool) error {
+	if mod.team.TeamConfig().IsReadOnly && args.Source.AccessLevel() < marvin.AccessLevelAdmin {
+		// Remove factoids from DB manually.
+		return errors.Errorf("Marvin is currently on read only mode.  No factoids can currently be removed.")
+	}
 	stmt, err := mod.team.DB().Prepare(sqlForgetFactoid)
 	if err != nil {
 		return errors.Wrap(err, "Database error")
@@ -411,6 +418,9 @@ func (mod *FactoidModule) ForgetFactoid(dbID int64, isForgotten bool) error {
 }
 
 func (mod *FactoidModule) LockFactoid(dbID int64, isLocked bool) error {
+	if mod.team.TeamConfig().IsReadOnly {
+		return errors.Errorf("Marvin is currently on read only mode.  No factoids can currently be locked.")
+	}
 	stmt, err := mod.team.DB().Prepare(sqlLockFactoid)
 	if err != nil {
 		return errors.Wrap(err, "Database error")

--- a/modules/factoid/factoid.go
+++ b/modules/factoid/factoid.go
@@ -77,8 +77,10 @@ func (mod *FactoidModule) Enable(team marvin.Team) {
 	team.RegisterCommand("r", remember)
 	team.RegisterCommand("forget", forget)
 
-	go mod.workerFDataChan()
-	go mod.workerFDataSync()
+	if !mod.team.TeamConfig().IsReadOnly {
+		go mod.workerFDataChan()
+		go mod.workerFDataSync()
+	}
 }
 
 func (mod *FactoidModule) Disable(t marvin.Team) {

--- a/modules/factoid/fdata.go
+++ b/modules/factoid/fdata.go
@@ -357,7 +357,7 @@ func (mod *FactoidModule) GetFDataValue(mapName, keyName string) ([]byte, error)
 }
 
 func (mod *FactoidModule) SetFDataValue(mapName, keyName string, val []byte) {
-	if mod.team.TeamConfig().IsReadOnly && args.Source.AccessLevel() < marvin.AccessLevelAdmin {
+	if mod.team.TeamConfig().IsReadOnly {
 		return
 	}
 	ch := make(chan interface{}, 1)

--- a/modules/factoid/fdata.go
+++ b/modules/factoid/fdata.go
@@ -357,6 +357,9 @@ func (mod *FactoidModule) GetFDataValue(mapName, keyName string) ([]byte, error)
 }
 
 func (mod *FactoidModule) SetFDataValue(mapName, keyName string, val []byte) {
+	if mod.team.TeamConfig().IsReadOnly && args.Source.AccessLevel() < marvin.AccessLevelAdmin {
+		return
+	}
 	ch := make(chan interface{}, 1)
 	mod.fdataReqChan <- fdataReq{C: ch, F: fdataFuncSetEntry(mapName, keyName, val)}
 	return
@@ -439,6 +442,7 @@ func luaFData_get(L *lua.LState) int {
 }
 
 func luaFData_set(L *lua.LState) int {
+
 	u := L.CheckUserData(1)
 	kv := L.Get(2)
 	if kv.Type() != lua.LTString {

--- a/modules/on_reaction/on_reaction.go
+++ b/modules/on_reaction/on_reaction.go
@@ -165,7 +165,7 @@ func (mod *OnReactionModule) ListenMessage(which slack.MessageID, modID marvin.M
 
 	stmt, err := mod.team.DB().Prepare(sqlListenMessage)
 	if mod.team.TeamConfig().IsReadOnly {
-		return errors.Errorf("Marvin is currently on read only mode.  No new reactions can currently be listened to.")
+		return errors.Errorf("Marvin is currently on read only.")
 	}
 	if err != nil {
 		return errors.Wrap(err, "on_reaction preparing SQL statement")

--- a/modules/on_reaction/on_reaction.go
+++ b/modules/on_reaction/on_reaction.go
@@ -164,6 +164,9 @@ func (mod *OnReactionModule) ListenMessage(which slack.MessageID, modID marvin.M
 	}
 
 	stmt, err := mod.team.DB().Prepare(sqlListenMessage)
+	if mod.team.TeamConfig().IsReadOnly {
+		return errors.Errorf("Marvin is currently on read only mode.  No new reactions can currently be listened to.")
+	}
 	if err != nil {
 		return errors.Wrap(err, "on_reaction preparing SQL statement")
 	}

--- a/modules/rss/rss.go
+++ b/modules/rss/rss.go
@@ -155,7 +155,7 @@ func (mod *RSSModule) CommandSubscribe(t marvin.Team, args *marvin.CommandArgume
 	// @marvin rss list
 	// @marvin rss
 	if mod.team.TeamConfig().IsReadOnly {
-		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No feeds can currently be subscribed.")
+		return marvin.CmdFailuref(args, "Marvin is currently on read only.")
 	}
 	if len(args.Arguments) == 0 {
 		return marvin.CmdUsage(args, usageSubscribe).WithSimpleUndo()

--- a/modules/rss/rss.go
+++ b/modules/rss/rss.go
@@ -154,6 +154,9 @@ func (mod *RSSModule) CommandSubscribe(t marvin.Team, args *marvin.CommandArgume
 	// @marvin rss {add|subscribe} [facebook|rss|twitter] https://www.facebook.com/42Born2CodeUS
 	// @marvin rss list
 	// @marvin rss
+	if mod.team.TeamConfig().IsReadOnly {
+		return marvin.CmdFailuref(args, "Marvin is currently on read only mode.  No feeds can currently be subscribed.")
+	}
 	if len(args.Arguments) == 0 {
 		return marvin.CmdUsage(args, usageSubscribe).WithSimpleUndo()
 	}

--- a/modules/weblogin/user.go
+++ b/modules/weblogin/user.go
@@ -219,7 +219,7 @@ func (mod *WebLoginModule) _getCurrentUser(create bool, w http.ResponseWriter, r
 	u, err := mod.GetUserByID(uid)
 	if err == ErrNoSuchUser {
 		if mod.team.TeamConfig().IsReadOnly {
-			return nil, errors.Errorf("Marvin is currently on read only mode.  No factoids can currently be created.")
+			return nil, errors.Errorf("Marvin is currently on read only.")
 		}
 		if !create {
 			return nil, nil

--- a/modules/weblogin/user.go
+++ b/modules/weblogin/user.go
@@ -218,6 +218,9 @@ func (mod *WebLoginModule) _getCurrentUser(create bool, w http.ResponseWriter, r
 
 	u, err := mod.GetUserByID(uid)
 	if err == ErrNoSuchUser {
+		if mod.team.TeamConfig().IsReadOnly {
+			return nil, errors.Errorf("Marvin is currently on read only mode.  No factoids can currently be created.")
+		}
 		if !create {
 			return nil, nil
 		} else {

--- a/team_config.go
+++ b/team_config.go
@@ -28,6 +28,7 @@ type TeamConfig struct {
 	HTTPURL         string
 	Controllers     []slack.UserID
 	IsDevelopment   bool
+	IsReadOnly   	bool
 }
 
 func LoadTeamConfig(sec *ini.Section) *TeamConfig {
@@ -44,6 +45,7 @@ func LoadTeamConfig(sec *ini.Section) *TeamConfig {
 	c.HTTPURL = sec.Key("HTTPURL").String()
 	c.LogChannel = slack.ChannelID(sec.Key("LogChannel").String())
 	c.IsDevelopment, _ = sec.Key("IsDevelopment").Bool()
+	c.IsReadOnly, _ = sec.Key("IsReadOnly").Bool()
 
 	var controllerKey = sec.Key("Controller").String()
 	var split = strings.Split(controllerKey, ",")


### PR DESCRIPTION
This adds an option in the configuration to make Marvin read only, so new data (factoids/sessions/data/invites/etc) will not be able to be saved.

This is to aid in assistance in migrating factoid data to the new Slack.