### PR TITLE
Test fix for cantina menu

### DIFF
--- a/modules/factoid/factoid.go
+++ b/modules/factoid/factoid.go
@@ -77,10 +77,8 @@ func (mod *FactoidModule) Enable(team marvin.Team) {
 	team.RegisterCommand("r", remember)
 	team.RegisterCommand("forget", forget)
 
-	if !mod.team.TeamConfig().IsReadOnly {
-		go mod.workerFDataChan()
-		go mod.workerFDataSync()
-	}
+	go mod.workerFDataChan()
+	go mod.workerFDataSync()
 }
 
 func (mod *FactoidModule) Disable(t marvin.Team) {


### PR DESCRIPTION
Disabling the worker FData function calls caused factoids that use factoid data mappings `fmap.XXX` to no longer work while in Read Only mode.  This should fix that problem.