### PR TITLE
Code Revamp for new Slack

### DIFF
--- a/modules/_all/import.go
+++ b/modules/_all/import.go
@@ -2,9 +2,10 @@
 package _all
 
 import (
+	_ "github.com/riking/marvin/modules/antiflood"
 	_ "github.com/riking/marvin/modules/atcommand"
 	_ "github.com/riking/marvin/modules/autoinvite"
-	_ "github.com/riking/marvin/modules/autoresponse"
+	//_ "github.com/riking/marvin/modules/autoresponse"
 	_ "github.com/riking/marvin/modules/awake"
 	_ "github.com/riking/marvin/modules/core"
 	_ "github.com/riking/marvin/modules/debug"

--- a/modules/antiflood/antiflood.go
+++ b/modules/antiflood/antiflood.go
@@ -1,0 +1,108 @@
+package antiflood
+
+import (
+	"fmt"
+	"github.com/riking/marvin-old/util"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/riking/marvin"
+	"github.com/riking/marvin/slack"
+)
+
+func init() {
+	marvin.RegisterModule(NewAntifloodModule)
+}
+
+const Identifier = "antiflood"
+
+type API interface {
+	marvin.Module
+
+	CheckChannel(channelID slack.ChannelID) bool
+}
+
+var _ API = &AntifloodModule{}
+
+type AntifloodModule struct {
+	marvin.Module
+
+	team marvin.Team
+
+	threshold time.Duration
+
+	recentChannels map[slack.ChannelID]time.Time
+	antifloodMutex sync.Mutex
+}
+
+func NewAntifloodModule(t marvin.Team) marvin.Module {
+	mod := &AntifloodModule{
+		team:           t,
+		recentChannels: make(map[slack.ChannelID]time.Time),
+	}
+	return mod
+}
+
+func (mod *AntifloodModule) Identifier() marvin.ModuleID {
+	return Identifier
+}
+
+func (mod *AntifloodModule) Load(t marvin.Team) {
+	c := mod.team.ModuleConfig(Identifier)
+	c.AddProtect(confKeyMsgThreshold, confThresholdDefault, true)
+	c.OnModify(func(key string) {
+		if strings.Compare(key, confKeyMsgThreshold) == 0 {
+			go mod.ReloadConfig()
+		}
+	})
+}
+
+func (mod *AntifloodModule) Enable(t marvin.Team) {
+	mod.ReloadConfig()
+}
+
+func (mod *AntifloodModule) Disable(t marvin.Team) {
+}
+
+// -----
+
+const (
+	confKeyMsgThreshold  = "threshold"
+	confThresholdDefault = "10s"
+)
+
+func (mod *AntifloodModule) ReloadConfig() {
+	val, _ := mod.team.ModuleConfig(Identifier).Get(confKeyMsgThreshold)
+	threshold, err := time.ParseDuration(val)
+	if err != nil {
+		util.LogBad(fmt.Sprintf("[%s] Configuration item %s is tainted, switching to default value of %s",
+			mod.team.Domain(), confKeyMsgThreshold, confThresholdDefault))
+		threshold, _ = time.ParseDuration(confThresholdDefault)
+	}
+	mod.antifloodMutex.Lock()
+	defer mod.antifloodMutex.Unlock()
+	mod.threshold = threshold
+}
+
+func (mod *AntifloodModule) CheckChannel(channelID slack.ChannelID) bool {
+	if channelID[0] == 'C' || channelID[0] == 'G' {
+		mod.antifloodMutex.Lock()
+		defer mod.antifloodMutex.Unlock()
+		if val, ok := mod.recentChannels[channelID]; ok {
+			if !val.Before(time.Now().Add(-mod.threshold)) || val.Unix() == 0 {
+				return false
+			} else {
+				mod.recentChannels[channelID] = time.Now()
+				return true
+			}
+		} else if !mod.team.TeamConfig().CheckChannelName(mod.team.ChannelName(channelID)) {
+			mod.recentChannels[channelID] = time.Unix(0, 0)
+			return false
+		} else {
+			// Should only be called only once per unrecognized channel.
+			mod.recentChannels[channelID] = time.Now()
+		}
+	}
+	return true
+}

--- a/modules/autoinvite/autoinvite.go
+++ b/modules/autoinvite/autoinvite.go
@@ -246,6 +246,10 @@ func (mod *AutoInviteModule) PostInvite(t marvin.Team, args *marvin.CommandArgum
 	}
 	util.LogDebug("PostInvite", args.Arguments)
 
+	if args.Source.AccessLevel() < marvin.AccessLevelController {
+		return marvin.CmdFailuref(args, "This command has been restricted to bot controller only.")
+	}
+
 	if len(args.Arguments) < 1 {
 		return marvin.CmdUsage(args, inviteHelp)
 	}
@@ -412,6 +416,10 @@ func (mod *AutoInviteModule) SaveInvite(
 func (mod *AutoInviteModule) CmdRevokeInvite(t marvin.Team, args *marvin.CommandArguments) marvin.CommandResult {
 	if mod.team.TeamConfig().IsReadOnly && args.Source.AccessLevel() < marvin.AccessLevelAdmin {
 		return marvin.CmdFailuref(args, "Marvin is currently on read only.")
+	}
+
+	if args.Source.AccessLevel() < marvin.AccessLevelController {
+		return marvin.CmdFailuref(args, "This command has been restricted to bot controller only.")
 	}
 	stmt, err := mod.team.DB().Prepare(sqlRevokeInvite)
 	if err != nil {

--- a/modules/autoresponse/autoresponse.go
+++ b/modules/autoresponse/autoresponse.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 
 	"github.com/riking/marvin"
+	"github.com/riking/marvin/modules/antiflood"
 	"github.com/riking/marvin/slack"
 )
 
@@ -59,6 +60,11 @@ var responses = []AutoEmojiResponse{
 func (mod *AutoResponseModule) OnMessage(_rtm slack.RTMRawMessage) {
 	rtm := slack.SlackTextMessage(_rtm)
 	text := rtm.Text()
+	// TODO: This module needs to check user's level with mod.team.UserLevel(_rtm.UserID())
+	//       However since it is not currently in use, the following code will stay here.
+	if !mod.team.GetModule(antiflood.Identifier).(antiflood.API).CheckChannel(rtm.ChannelID()) {
+		return
+	}
 
 	for _, v := range responses {
 		if v.Regexp.FindString(text) != "" {

--- a/slack/controller/channel_info.go
+++ b/slack/controller/channel_info.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"bytes"
 	"fmt"
+	"github.com/pkg/errors"
 	"net/url"
 	"regexp"
 	"strings"
@@ -195,6 +196,9 @@ func (t *Team) cachedUserInfo(user slack.UserID) *slack.User {
 }
 
 func (t *Team) UserInfo(user slack.UserID) (*slack.User, error) {
+	if len(user) < 1 {
+		return nil, errors.New("User ID blank in UserInfo call!")
+	}
 	info := t.cachedUserInfo(user)
 	if info != nil {
 		return info, nil
@@ -211,6 +215,9 @@ func (t *Team) updateUserInfo(user slack.UserID) (*slack.User, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Replace Name with normalized display name for now.
+	// TODO: Rename all usages of u.Name to u.Profile.DisplayName
+	response.User.Name = response.User.Profile.DisplayName
 	t.client.ReplaceUserObject(response.User)
 	return response.User, nil
 }

--- a/slack/slackobjects.go
+++ b/slack/slackobjects.go
@@ -85,44 +85,47 @@ type User struct {
 	NotExist bool      `json:"-"`
 	CacheTS  time.Time `json:"-"`
 
-	ID       UserID      `json:"id"`
-	TeamID   TeamID      `json:"team_id"`
-	Name     string      `json:"name"`
-	Deleted  bool        `json:"deleted"`
-	Status   interface{} `json:"status"`
-	Color    string      `json:"color"`
-	RealName string      `json:"real_name"`
-	Tz       string      `json:"tz"`
-	TzLabel  string      `json:"tz_label"`
-	TzOffset int         `json:"tz_offset"`
-	Updated  int64       `json:"updated"`
-	Profile  struct {
-		RealName           string `json:"real_name"`
-		RealNameNormalized string `json:"real_name_normalized"`
-		FirstName          string `json:"first_name"`
-		LastName           string `json:"last_name"`
-		Email              string `json:"email"`
-		Phone              string `json:"phone"`
-		Title              string `json:"title"`
-		Skype              string `json:"skype"`
-		Image24            string `json:"image_24"`
-		Image32            string `json:"image_32"`
-		Image48            string `json:"image_48"`
-		Image72            string `json:"image_72"`
-		Image128           string `json:"image_128"`
-		Image192           string `json:"image_192"`
-		Image512           string `json:"image_512"`
-		Image1024          string `json:"image_1024"`
-		ImageOriginal      string `json:"image_original"`
-	} `json:"profile"`
-	IsAdmin           bool   `json:"is_admin"`
-	IsOwner           bool   `json:"is_owner"`
-	IsPrimaryOwner    bool   `json:"is_primary_owner"`
-	IsRestricted      bool   `json:"is_restricted"`
-	IsUltraRestricted bool   `json:"is_ultra_restricted"`
-	IsBot             bool   `json:"is_bot"`
-	Presence          string `json:"presence"`
-	Has2Fa            bool   `json:"has_2fa,omitempty"`
+	ID                UserID      `json:"id"`
+	TeamID            TeamID      `json:"team_id"`
+	Name              string      `json:"-"`
+	Deleted           bool        `json:"deleted"`
+	Status            interface{} `json:"status"`
+	Color             string      `json:"color"`
+	RealName          string      `json:"real_name"`
+	Tz                string      `json:"tz"`
+	TzLabel           string      `json:"tz_label"`
+	TzOffset          int         `json:"tz_offset"`
+	Updated           int64       `json:"updated"`
+	Profile           Profile     `json:"profile"`
+	IsAdmin           bool        `json:"is_admin"`
+	IsOwner           bool        `json:"is_owner"`
+	IsPrimaryOwner    bool        `json:"is_primary_owner"`
+	IsRestricted      bool        `json:"is_restricted"`
+	IsUltraRestricted bool        `json:"is_ultra_restricted"`
+	IsBot             bool        `json:"is_bot"`
+	Presence          string      `json:"presence"`
+	Has2Fa            bool        `json:"has_2fa,omitempty"`
+}
+
+type Profile struct {
+	DisplayName        string `json:"display_name_normalized"`
+	RealName           string `json:"real_name"`
+	RealNameNormalized string `json:"real_name_normalized"`
+	FirstName          string `json:"first_name"`
+	LastName           string `json:"last_name"`
+	Email              string `json:"email"`
+	Phone              string `json:"phone"`
+	Title              string `json:"title"`
+	Skype              string `json:"skype"`
+	Image24            string `json:"image_24"`
+	Image32            string `json:"image_32"`
+	Image48            string `json:"image_48"`
+	Image72            string `json:"image_72"`
+	Image128           string `json:"image_128"`
+	Image192           string `json:"image_192"`
+	Image512           string `json:"image_512"`
+	Image1024          string `json:"image_1024"`
+	ImageOriginal      string `json:"image_original"`
 }
 
 func (u *User) Avatar(size int) string {

--- a/team_config.go
+++ b/team_config.go
@@ -28,6 +28,7 @@ type TeamConfig struct {
 	HTTPURL         string
 	Controllers     []slack.UserID
 	ChannelPrefix   slack.ChannelID
+	IsSlackAdmin    bool
 	IsDevelopment   bool
 	IsReadOnly   	bool
 }
@@ -46,6 +47,7 @@ func LoadTeamConfig(sec *ini.Section) *TeamConfig {
 	c.HTTPURL = sec.Key("HTTPURL").String()
 	c.LogChannel = slack.ChannelID(sec.Key("LogChannel").String())
 	c.ChannelPrefix = slack.ChannelID(sec.Key("ChannelPrefix").String())
+	c.IsSlackAdmin, _ = sec.Key("IsSlackAdmin").Bool()
 	c.IsDevelopment, _ = sec.Key("IsDevelopment").Bool()
 	c.IsReadOnly, _ = sec.Key("IsReadOnly").Bool()
 


### PR DESCRIPTION
Since 42 has switched to a new Slack workspace, joined by the other campuses, some changes to Marvin were required.

Luckily these changes have now finally landed.

I am going to make sure these changes work as expected, then merge & deploy shortly thereafter.  

The new method of downloading new members list (via fetching CSV) is kind of messy, but it is absolutely needed as the # of members on the new Slack is enormous (>7000). 